### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-alpine AS backend
+FROM golang:1.17-alpine AS backend
 
 RUN apk add --no-cache ca-certificates git
 WORKDIR /go/src/github.com/RocketChat/filestore-migrator


### PR DESCRIPTION
bump golang version due to compilation error:

6.828 # golang.org/x/net/http2
6.828 /go/pkg/mod/golang.org/x/net@v0.0.0-20220722155237-a158d28d115b/http2/transport.go:416:45: undefined: os.ErrDeadlineExceeded 6.828 note: **module requires Go 1.17**