### PR TITLE
feat: add BucketPrefix support for S3 destination

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -40,12 +40,13 @@ type MigrateTargetGoogleStorage struct {
 }
 
 type MigrateTargetS3 struct {
-	Endpoint  string `yaml:"endpoint"`
-	Bucket    string `yaml:"bucket"`
-	AccessID  string `yaml:"accessId"`
-	AccessKey string `yaml:"accessKey"`
-	Region    string `yaml:"region"`
-	UseSSL    bool   `yaml:"useSSL"`
+	Endpoint     string `yaml:"endpoint"`
+	Bucket       string `yaml:"bucket"`
+	BucketPrefix string `yaml:"bucketPrefix"`
+	AccessID     string `yaml:"accessId"`
+	AccessKey    string `yaml:"accessKey"`
+	Region       string `yaml:"region"`
+	UseSSL       bool   `yaml:"useSSL"`
 }
 
 type MigrateTargetFileSystem struct {

--- a/migrate.go
+++ b/migrate.go
@@ -183,12 +183,13 @@ func New(config *config.Config, skipErrors bool) (*Migrate, error) {
 			}
 
 			destinationStore := &store.S3Provider{
-				Endpoint:  config.Destination.AmazonS3.Endpoint,
-				AccessID:  config.Destination.AmazonS3.AccessID,
-				AccessKey: config.Destination.AmazonS3.AccessKey,
-				Region:    config.Destination.AmazonS3.Region,
-				Bucket:    config.Destination.AmazonS3.Bucket,
-				UseSSL:    config.Destination.AmazonS3.UseSSL,
+				Endpoint:     config.Destination.AmazonS3.Endpoint,
+				AccessID:     config.Destination.AmazonS3.AccessID,
+				AccessKey:    config.Destination.AmazonS3.AccessKey,
+				Region:       config.Destination.AmazonS3.Region,
+				Bucket:       config.Destination.AmazonS3.Bucket,
+				BucketPrefix: config.Destination.AmazonS3.BucketPrefix,
+				UseSSL:       config.Destination.AmazonS3.UseSSL,
 			}
 
 			migrate.destinationStore = destinationStore

--- a/store/s3.go
+++ b/store/s3.go
@@ -17,6 +17,7 @@ import (
 type S3Provider struct {
 	Endpoint         string
 	Bucket           string
+	BucketPrefix     string
 	AccessID         string
 	AccessKey        string
 	Region           string
@@ -76,6 +77,10 @@ func (s *S3Provider) Download(fileCollection string, file rocketchat.File) (stri
 
 // Upload will upload the file from given file path
 func (s *S3Provider) Upload(objectPath string, filePath string, contentType string) error {
+	if s.BucketPrefix != "" {
+		objectPath = s.BucketPrefix + "/" + objectPath
+	}
+
 	minioClient, err := minio.New(s.Endpoint, &minio.Options{
 		Creds:  credentials.NewStaticV4(s.AccessID, s.AccessKey, ""),
 		Secure: s.UseSSL,


### PR DESCRIPTION
Adds ability to specify a prefix for S3 object paths.

**Use case:**
- Multiple RocketChat instances sharing same S3 bucket
- Custom path structure requirements
- Namespace separation

**Changes:**
- Added `bucketPrefix` field to S3 configuration
- Updated path construction in S3Provider.Upload()

**Example:**
````yaml
destination:
  AmazonS3:
    bucketPrefix: " "  # Will prefix all paths with a space
````
