### PR TITLE
feat: add automatic cleanup of temporary files after upload

### DIFF
--- a/methods.go
+++ b/methods.go
@@ -182,6 +182,7 @@ func (m *Migrate) MigrateStore() error {
 		if err := m.destinationStore.Upload(objectPath, downloadedPath, file.Type); err != nil {
 			return err
 		}
+		os.Remove(downloadedPath)
 
 		set, unset := m.fixFileForUpload(&file, objectPath)
 


### PR DESCRIPTION
Prevents disk space exhaustion during large migrations by removing
temporary files after successful upload.

**Problem:**
During migration of hundreds of thousands of files, temporary
files accumulate in tempFileLocation, potentially filling the disk.

**Solution:**
- Add os.Remove() after successful upload
- Only cleanup after successful upload (data safety)

**Testing:**
Tested with 450k+ files migration, temp directory stays minimal.