### PR TITLE
feat: support file extensions in FileSystem source

### DIFF
--- a/methods.go
+++ b/methods.go
@@ -183,14 +183,18 @@ func (m *Migrate) MigrateStore() error {
 			return err
 		}
 
-		set, unset := m.fixFileForUpload(&file, objectPath)
+		set, unsetFields := m.fixFileForUpload(&file, objectPath)
 
 		update := bson.M{
 			"$set": set,
 		}
 
-		if unset != "" {
-			update["$unset"] = bson.M{unset: 1}
+		if len(unsetFields) > 0 {
+			unsetDoc := bson.M{}
+			for _, field := range unsetFields {
+				unsetDoc[field] = 1
+			}
+			update["$unset"] = unsetDoc
 		}
 
 		db := m.session.Client().Database(m.databaseName)
@@ -238,10 +242,8 @@ func (m *Migrate) getObjectPath(file *rocketchat.File) string {
 	return objectPath
 }
 
-func (m *Migrate) fixFileForUpload(file *rocketchat.File, objectPath string) (rocketchat.FileSetOp, string) {
-	// what to unset
-	unset := ""
-
+func (m *Migrate) fixFileForUpload(file *rocketchat.File, objectPath string) (rocketchat.FileSetOp, []string) {
+	var unsetFields []string
 	set := rocketchat.FileSetOp{}
 
 	switch m.destinationStore.StoreType() {
@@ -250,16 +252,21 @@ func (m *Migrate) fixFileForUpload(file *rocketchat.File, objectPath string) (ro
 			Path: objectPath,
 		}
 
-		// Set to empty object so won't be saved back
-		unset = "GoogleStorage"
+		unsetFields = append(unsetFields, "GoogleStorage")
+		if file.Extension != "" {
+			unsetFields = append(unsetFields, "extension")
+		}
 
 	case "GoogleCloudStorage":
 		set.GoogleStorage = &rocketchat.GoogleStorage{
 			Path: objectPath,
 		}
 
-		// Set to empty object so won't be saved back
-		unset = "AmazonS3"
+		unsetFields = append(unsetFields, "AmazonS3")
+		if file.Extension != "" {
+			unsetFields = append(unsetFields, "extension")
+		}
+
 	case "FileSystem":
 	default:
 	}
@@ -270,7 +277,7 @@ func (m *Migrate) fixFileForUpload(file *rocketchat.File, objectPath string) (ro
 	set.Path = ufsPath
 	set.Store = m.destinationStore.StoreType() + ":" + m.storeName
 
-	return set, unset
+	return set, unsetFields
 }
 
 // SetFileOffset sets an offset for file upload/downloads
@@ -366,14 +373,18 @@ func (m *Migrate) UploadAll(filesRoot string) error {
 			return err
 		}
 
-		set, unset := m.fixFileForUpload(&file, objectPath)
+		set, unsetFields := m.fixFileForUpload(&file, objectPath)
 
 		update := bson.M{
 			"$set": set,
 		}
 
-		if unset != "" {
-			update["$unset"] = bson.M{unset: 1}
+		if len(unsetFields) > 0 {
+			unsetDoc := bson.M{}
+			for _, field := range unsetFields {
+				unsetDoc[field] = 1
+			}
+			update["$unset"] = unsetDoc
 		}
 
 		collection := m.session.Client().Database(m.databaseName).Collection(m.fileCollectionName)

--- a/store/fs.go
+++ b/store/fs.go
@@ -29,7 +29,13 @@ func (f *FileSystemStorageProvider) Download(fileCollection string, file rocketc
 	sourcePath := f.Location + "/" + file.ID
 
 	if file.Extension != "" {
-		sourcePath = sourcePath + "." + file.Extension
+		pathWithExt := sourcePath + "." + file.Extension
+		// Try with extension first
+		if _, err := os.Stat(pathWithExt); err == nil {
+			sourcePath = pathWithExt
+		}
+		// If file with extension doesn't exist, try without extension
+		// (falls through to use original sourcePath)
 	}
 
 	destinationPath := f.TempFileLocation + "/" + file.ID

--- a/store/fs.go
+++ b/store/fs.go
@@ -27,6 +27,11 @@ func (f *FileSystemStorageProvider) SetTempDirectory(dir string) {
 // Download downloads a file from the storage provider and moves it to the temporary file store
 func (f *FileSystemStorageProvider) Download(fileCollection string, file rocketchat.File) (string, error) {
 	sourcePath := f.Location + "/" + file.ID
+
+	if file.Extension != "" {
+		sourcePath = sourcePath + "." + file.Extension
+	}
+
 	destinationPath := f.TempFileLocation + "/" + file.ID
 
 	if _, err := os.Stat(sourcePath); os.IsNotExist(err) {


### PR DESCRIPTION
FileSystem storage may store files with extensions (ID.extension),
while S3/Google stores without extensions (ID only).

**Problem:**
Migration failed for ~30k files that had extensions in FileSystem
because the code only looked for files without extensions.

**Solution:**
- Check for file.Extension field in MongoDB
- Append extension when reading from FileSystem
- Remove extension field from MongoDB after migration to S3/Google

**Changes:**
- store/fs.go: Append extension to source path if present
- methods.go: Remove extension field in fixFileForUpload()

**Backward compatible:**
Works with both files with and without extensions.